### PR TITLE
Custom config for backoffice

### DIFF
--- a/app/controllers/trades_controller.rb
+++ b/app/controllers/trades_controller.rb
@@ -42,6 +42,7 @@ class TradesController < ApplicationController
       .permit(
         :state,
         :settlement_date,
+        custom_instance: Backoffice.custom_class(params[:trade][:portfolio_id]).fields.map(&:key),
       )
   end
 

--- a/app/helpers/trades_helper.rb
+++ b/app/helpers/trades_helper.rb
@@ -3,6 +3,8 @@ module TradesHelper
     case field.type
     when 'string'
       form.text_field field.key, class: "#{options[:class]} form-control"
+    when 'number'
+      form.text_field field.key, type: 'number', min: 0, step: 1, class: "#{options[:class]} form-control"
     when 'list'
       form.select field.key, options_for_select(field.values), class: "#{options[:class]} form-control"
     end

--- a/app/models/backoffice.rb
+++ b/app/models/backoffice.rb
@@ -1,5 +1,10 @@
 class Backoffice < ApplicationRecord
+  include CustomFields
+  setup_custom_field :portfolio_id, config_type: CustomConfig::BACKOFFICE_FIELDS
+
   belongs_to :trade, foreign_key: :trade_uid, primary_key: :uid
+
+  delegate :portfolio_id, to: :trade
 
   validates :state, presence: true
   validates :version, presence: true

--- a/app/models/concerns/custom_fields.rb
+++ b/app/models/concerns/custom_fields.rb
@@ -36,7 +36,7 @@ module CustomFields
       config = CustomConfig.find_by(
         owner_id: key_id,
         owner_type: @_custom_field_class.to_s,
-        config_type: @_config_type
+        config_type: @_config_type,
       )
       return CustomField if config.nil?
       const_set(name, build_class(config))

--- a/app/models/custom_config.rb
+++ b/app/models/custom_config.rb
@@ -2,6 +2,7 @@ class CustomConfig < ApplicationRecord
   CONFIG_TYPES = [
     SETTINGS = 'settings'.freeze,
     TRADE_FIELDS = 'trade_fields'.freeze,
+    BACKOFFICE_FIELDS = 'backoffice_fields'.freeze,
   ].freeze
 
   DEFAULT_CONFIG = {
@@ -21,8 +22,7 @@ class CustomConfig < ApplicationRecord
 
   class << self
     def fields_for(object)
-      return nil unless object
-      find_by(owner_type: object.class.to_s, owner_id: object.id, config_type: TRADE_FIELDS)
+      find_for(object, config_type: TRADE_FIELDS)
     end
 
     def find_for(object, config_type: SETTINGS)

--- a/app/services/event_saver.rb
+++ b/app/services/event_saver.rb
@@ -17,6 +17,8 @@ class EventSaver
     )
   end
 
+  private
+
   def object_to_logables(object)
     trade = get_trade(object)
     portfolio = get_portfolio(trade, object)
@@ -70,7 +72,29 @@ class EventSaver
     to ||= {}
     fields = from.keys | to.keys
     fields.each_with_object({}) do |field, hash|
-      hash[field] = [from[field], to[field]]
+      hash[field] = [from[field], to[field]] unless matching?(from[field], to[field])
     end
+  end
+
+  def matching?(left, right)
+    return false unless left.class == right.class
+    case left
+    when Array
+      matching_array?(left, right)
+    when Hash
+      matching_hash?(left, right)
+    else
+      left == right
+    end
+  end
+
+  def matching_array?(left, right)
+    left.count == right.count &&
+      left.sort.zip(right.sort).all? { |l, r| matching?(l, r) }
+  end
+
+  def matching_hash?(left, right)
+    left.keys.length == right.keys.length &&
+      left.all? { |k, v| matching?(v, right[k]) }
   end
 end

--- a/app/views/configs/_custom_fields.html.slim
+++ b/app/views/configs/_custom_fields.html.slim
@@ -3,14 +3,21 @@
     table.table.table-striped
       thead
         tr
+          th style='width: 80px'
           th Name
           th Default
           th Type
           th Validations
       tbody
-        - config.each do |key, details|
+        - custom_config.config.each do |key, details|
           tr.t-field
-            td= details['name']
+            td
+              = link_to config_field_path(id: custom_config.id, key: key), method: :delete, 'data-confirm' => 'Are you sure you want to delete this field?', class: 't-delete' do
+                i.fa.fa-trash.fa-lg.warning  title='Delete'
+              '  |
+              = link_to edit_config_field_path(id: custom_config.id, key: key), class: 't-edit' do
+                i.fa.fa-edit.fa-lg title='Edit'
+            td.t-field-name= details['name']
             td= details['default']
             td= (details['type'] || '').humanize
             td= details['validations'] && details['validations'].keys.to_sentence.humanize

--- a/app/views/configs/_portfolios.html.slim
+++ b/app/views/configs/_portfolios.html.slim
@@ -16,6 +16,9 @@
         .col-md-12
           h3 Trade fields
         = render 'configs/custom_fields', config: config_for(portfolio, config_type: CustomConfig::TRADE_FIELDS)&.config
+        .col-md-12
+          h3 Backoffice fields
+        = render 'configs/custom_fields', config: config_for(portfolio, config_type: CustomConfig::BACKOFFICE_FIELDS)&.config
       .row
         .form_group.col-md-12
           = f.submit 'Update', class: 'btn btn-primary t-save'

--- a/app/views/configs/_portfolios.html.slim
+++ b/app/views/configs/_portfolios.html.slim
@@ -15,10 +15,10 @@
         = render 'configs/fields', config: @portfolio&.id == portfolio.id ? params[:config] : config_for(current_portfolio)&.config
         .col-md-12
           h3 Trade fields
-        = render 'configs/custom_fields', config: config_for(portfolio, config_type: CustomConfig::TRADE_FIELDS)&.config
+        = render 'configs/custom_fields', custom_config: config_for(portfolio, config_type: CustomConfig::TRADE_FIELDS)
         .col-md-12
           h3 Backoffice fields
-        = render 'configs/custom_fields', config: config_for(portfolio, config_type: CustomConfig::BACKOFFICE_FIELDS)&.config
+        = render 'configs/custom_fields', custom_config: config_for(portfolio, config_type: CustomConfig::BACKOFFICE_FIELDS)
       .row
         .form_group.col-md-12
           = f.submit 'Update', class: 'btn btn-primary t-save'

--- a/app/views/fields/new.html.slim
+++ b/app/views/fields/new.html.slim
@@ -17,6 +17,10 @@
               label.form-check-label
                 = f.radio_button :config_type, CustomConfig::TRADE_FIELDS, class: 'form-check-input t-config-type'
                 ' Trade adjustment
+            .form-check.form-check-inline
+              label.form-check-label
+                = f.radio_button :config_type, CustomConfig::BACKOFFICE_FIELDS, class: 'form-check-input t-config-type'
+                ' Trade tracking/settlement
 
       .row
         .form-group.col-md-8.col-xl-6

--- a/app/views/fields/new.html.slim
+++ b/app/views/fields/new.html.slim
@@ -16,11 +16,11 @@
             .form-check.form-check-inline
               label.form-check-label
                 = f.radio_button :config_type, CustomConfig::TRADE_FIELDS, class: 'form-check-input t-config-type'
-                ' Trade adjustment
+                '  Trade adjustment
             .form-check.form-check-inline
               label.form-check-label
                 = f.radio_button :config_type, CustomConfig::BACKOFFICE_FIELDS, class: 'form-check-input t-config-type'
-                ' Trade tracking/settlement
+                '  Trade tracking/settlement
 
       .row
         .form-group.col-md-8.col-xl-6

--- a/app/views/home/about.html.slim
+++ b/app/views/home/about.html.slim
@@ -6,12 +6,18 @@
       everything and anything could be added by configuration, ever data fields and that this would allow greater freedom
       for users.
 
-    p Want a feature, then please don't hestitate to contact me david@decoybecoy.com.
+    p Want a feature, then please don't hesitate to contact me david@decoybecoy.com.
 
 .row
   .col-md-6
     h2 In Progress
     ul
+
+    h2 Completed
+    | 6 Feb 2017
+    ul
+      li map config data in event object before saving
+      li Custom field setup
 
     h2 Completed
     | 23 Jan 2017
@@ -61,21 +67,22 @@
     h2 Pending for alpha - prioritised in planned order of implementation
 
     ul
-      li map config data in event object before saving
-      li current pricing
+      li add bugmuncher for feedback
+      li add bugsnag for error logging
+      li add GA - because Chris was right
+      li additional custom field types: boolean, date, cash (triggering cash balance event)
+      li create default portfolio option - pre-configure with default fields
+      li currency pricing
       li reporting currency
       li Add backoffice state config
       li retrieve user image (picture) during google oauth
       li timezone issues related to dates
       li allow comments to be created on trades/portfolios.
       li generation of dummy trades to show potential
-      li Custom field setup
       li Backoffice functionality for managing trade settlement
       li Implement roles
       li Reporting
       li Rules engine to allow dynamic validations
-      li add bugmuncher for feedback
-      li add bugsnag for error logging
       li add new relic for performance monitoring
       li better menu/navigation system
 

--- a/app/views/trades/_backoffice.html.slim
+++ b/app/views/trades/_backoffice.html.slim
@@ -8,3 +8,10 @@
     .form-group.col-md-8
       = b.label :settlement_date
       = b.date_field :settlement_date, class: 'form-control'
+
+  = b.fields_for(:custom_instance, b.object.custom_instance) do |c|
+    - c.object.each do |cf|
+      .row
+        .form-group.col-md-8.col-xl-6
+          = c.label cf.key
+          = field_for(cf, c, class: 't-custom-field')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
   resource :business, only: %i(show new create)
   resource :config, only: %i(show update) do
     resource :business, only: %i(update)
-    resources :fields, only: %i(new create)
+    resources :fields, only: %i(new create edit destroy)
     resources :portfolios, only: %i(update create)
     resources :users, only: %i(update create)
   end

--- a/spec/features/custom_trade_fields/backoffice_string_field_spec.rb
+++ b/spec/features/custom_trade_fields/backoffice_string_field_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.feature 'Trade with backoffice custom string field' do
+  scenario 'with no default' do
+    fields = FieldForm.new(
+      name: 'Description',
+      type: 'string',
+    )
+
+    create_trade_page(fields, config_type: CustomConfig::BACKOFFICE_FIELDS) do |page|
+      page.create_trade
+      page.edit_trade(Trade.first.uid, description: 'No default')
+
+      expect(Trade.count).to eq(1)
+      expect(Trade.first.backoffice.custom_instance).to have_attributes(description: 'No default')
+
+      trade_event = Event.find_by(owner_type: 'Trade', event_type: 'create')
+      expect(trade_event).to have_attributes(
+        details: {
+          'date' => [nil, Time.zone.today.strftime('%Y-%m-%d')],
+          'price' => [nil, '12.34'],
+          'currency' => [nil, 'AUD'],
+          'quantity' => [nil, 100],
+          'security_id' => [nil, trade_event.trade.security_id],
+          'portfolio_id' => [nil, trade_event.trade.portfolio_id],
+        },
+      )
+
+      backoffice_event = Event.find_by(owner_type: 'Backoffice', event_type: 'edit')
+      expect(backoffice_event).to have_attributes(
+        details: {
+          'description' => [nil, 'No default'],
+        },
+      )
+    end
+  end
+end

--- a/spec/features/custom_trade_fields/can_delete_spec.rb
+++ b/spec/features/custom_trade_fields/can_delete_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.feature 'Custom config field' do
+  scenario 'can delete a custom config field' do
+    navigate_to_field_config_page(animal: { name: 'Animal' }, fruit: { name: 'Fruit' }) do |page, portfolio|
+      expect(page.portfolios.first.fields.count).to eq(2)
+
+      page.delete_field('Animal')
+
+      expect(page.portfolios.first.fields.count).to eq(1)
+
+      expect(CustomConfig.fields_for(portfolio)).to have_attributes(
+        config_type: CustomConfig::TRADE_FIELDS,
+        config: {
+          'fruit' => {
+            'name' => 'Fruit',
+          },
+        },
+      )
+
+      event = Event.find_by(owner_type: 'CustomConfig', event_type: 'edit')
+      expect(event).to have_attributes(
+        details: {
+          'animal' => [
+            {
+              'name' => 'Animal',
+            },
+            nil,
+          ],
+        },
+      )
+    end
+  end
+
+  scenario 'can delete a custom config field when portfolio has existing trades' do
+    navigate_to_field_config_page(animal: { name: 'Animal' }, fruit: { name: 'Fruit' }) do |page, portfolio|
+      security = create(:security, business: portfolio.business)
+      create(:trade, portfolio: portfolio, security: security)
+
+      expect(page.portfolios.first.fields.count).to eq(2)
+
+      page.delete_field('Animal')
+
+      expect(page.portfolios.first.fields.count).to eq(1)
+      expect(portfolio).not_to eq(Portfolio.find_by(uid: portfolio.uid))
+    end
+  end
+end

--- a/spec/features/custom_trade_fields/setting_up_a_backoffice_string_field_spec.rb
+++ b/spec/features/custom_trade_fields/setting_up_a_backoffice_string_field_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.feature 'Custom config field' do
+  scenario 'can created a text field on the backoffice table' do
+    create_field_config_page do |page, portfolio|
+      config_page = ConfigFieldPage.new
+      config_page.add_fruit_field(CustomConfig::BACKOFFICE_FIELDS)
+
+      expect(page.portfolios.first.fields.count).to eq(1)
+
+      expect(CustomConfig.find_for(portfolio, config_type: CustomConfig::BACKOFFICE_FIELDS)).to have_attributes(
+        config_type: CustomConfig::BACKOFFICE_FIELDS,
+        config: {
+          'fruit_field' => {
+            'name' => 'Fruit field',
+            'type' => 'string',
+            'validations' => {
+              'presence' => true,
+            },
+            'default' => 'apples',
+          },
+        },
+      )
+    end
+  end
+end

--- a/spec/features/custom_trade_fields/setting_up_a_list_field_spec.rb
+++ b/spec/features/custom_trade_fields/setting_up_a_list_field_spec.rb
@@ -36,6 +36,8 @@ RSpec.feature 'Custom config field' do
 
       expect(page.portfolios.first.fields.count).to eq(1)
 
+      expect(portfolio).not_to eq(Portfolio.find_by(uid: portfolio.uid))
+
       event = Event.find_by(owner_type: 'CustomConfig', event_type: 'edit')
       expect(event).to have_attributes(
         details: {

--- a/spec/support/create_trade_page.rb
+++ b/spec/support/create_trade_page.rb
@@ -1,11 +1,11 @@
 module CreateTradePage
-  def create_trade_page(config_fields)
+  def create_trade_page(config_fields, config_type: CustomConfig::TRADE_FIELDS)
     business = create(:business)
     portfolio = create(:portfolio, business: business)
     create(:security, business: business)
     user = create(:user, business: business)
 
-    create(:custom_config, owner: portfolio, config_type: CustomConfig::TRADE_FIELDS, config: config_fields.as_json)
+    create(:custom_config, owner: portfolio, config_type: config_type, config: config_fields.as_json)
 
     with_user(user) do
       page = PortfolioPage.new

--- a/spec/support/field_config_page.rb
+++ b/spec/support/field_config_page.rb
@@ -1,5 +1,13 @@
-module CreateTradePage
-  def create_field_config_page(field_config = nil) # rubocop:disable Metrics/MethodLength
+module FieldConfigPage
+  def create_field_config_page(field_config = nil)
+    navigate_to_field_config_page(field_config) do |page, portfolio|
+      page.portfolios.first.add_field.click
+
+      yield page, portfolio
+    end
+  end
+
+  def navigate_to_field_config_page(field_config = nil) # rubocop:disable Metrics/MethodLength
     business = create(:business, :with_config)
     portfolio = create(:portfolio, :with_config, business: business)
 
@@ -21,7 +29,6 @@ module CreateTradePage
 
       # can update the user name
       page.tab("portfolio's")
-      page.portfolios.first.add_field.click
 
       yield page, portfolio
     end
@@ -29,5 +36,5 @@ module CreateTradePage
 end
 
 RSpec.configure do |config|
-  config.include CreateTradePage
+  config.include FieldConfigPage
 end

--- a/spec/support/pages/config_field_page.rb
+++ b/spec/support/pages/config_field_page.rb
@@ -1,6 +1,7 @@
 class ConfigFieldPage < SitePrism::Page
   element :name, '.t-name'
   elements :type_options, '.t-type'
+  elements :config_type_options, '.t-config-type'
   element :default, '.t-default'
   element :values, '.t-values'
 
@@ -13,7 +14,12 @@ class ConfigFieldPage < SitePrism::Page
     type_options.detect { |type_option| type_option['value'] == type }.set(true)
   end
 
-  def add_fruit_field
+  def config_type=(type)
+    config_type_options.detect { |type_option| type_option['value'] == type }.set(true)
+  end
+
+  def add_fruit_field(config_type = CustomConfig::TRADE_FIELDS)
+    self.config_type = config_type
     name.set('Fruit field')
     self.type = 'string'
     validates_presence.set(true)
@@ -21,7 +27,8 @@ class ConfigFieldPage < SitePrism::Page
     save.click
   end
 
-  def add_animal_field
+  def add_animal_field(config_type = CustomConfig::TRADE_FIELDS)
+    self.config_type = config_type
     name.set('Animal field')
     self.type = 'list'
     validates_presence.set(true)

--- a/spec/support/pages/config_page.rb
+++ b/spec/support/pages/config_page.rb
@@ -13,7 +13,10 @@ class ConfigPage < SitePrism::Page
     element :portfolio_name, '.t-portfolio-name'
     element :allow_negative_positions, '.t-allow-negative-positions-yes'
 
-    elements :fields, '.t-field'
+    sections :fields, '.t-field' do
+      element :field_name, '.t-field-name'
+      element :delete_button, '.t-delete'
+    end
 
     element :save, '.t-save'
     element :add_field, '.t-add-field-config'
@@ -26,5 +29,10 @@ class ConfigPage < SitePrism::Page
 
   def tab(tab_name)
     tabs.detect { |tab| tab.text.downcase == tab_name.to_s }.click
+  end
+
+  def delete_field(field_name)
+    field = portfolios.first.fields.detect { |f| f.field_name.text == field_name }
+    field.delete_button.click
   end
 end

--- a/spec/support/pages/edit_trade_page.rb
+++ b/spec/support/pages/edit_trade_page.rb
@@ -9,28 +9,46 @@ class EditTradePage < SitePrism::Page
   element :currency, '.t-currency'
   element :security, '.t-security'
 
+  # custom fields
+  elements :custom_fields, '.t-custom-field'
+
   # backoffice
   element :state, '.t-state'
 
   element :update_trade, '.t-update-trade'
 
-  def fill_in_trade(custom = {})
+  def fill_in_trade(custom = {}) # rubocop:disable Metrics/MethodLength
     update(:date, :set, custom, :date)
     update(:quantity, :set, custom, :quantity)
     update(:price, :set, custom, :price)
     update(:currency, :set, custom, :currency)
     update(:security, :select, custom, :security)
     update("direction_#{custom[:direction]}", :select, custom, :direction)
-
     update(:state, :set, custom, :state)
+
+    custom.each do |field_name, value|
+      field = find_custom(field_name)
+      next unless field
+      set_custom(field, value)
+    end
+  end
+
+  def save
+    update_trade.click
+  end
+
+  private
+
+  def find_custom(field_name)
+    custom_fields.detect { |elem| elem['name'] =~ /\[#{field_name}\]$/ }
+  end
+
+  def set_custom(field, value)
+    field.set value
   end
 
   def update(field, method, data, key)
     return unless data.key?(key)
     public_send(field).send(method, data[key])
-  end
-
-  def save
-    update_trade.click
   end
 end


### PR DESCRIPTION
Update custom config so that it can work on multiple classes. It requires a `custom` field to store the JSON data for the fields.

In addition, custom fields can now be edited and deleted via the interface. Create a new custom field with a name that matches as existing custom field name is still allowed and will overwrite the existing field.

