### PR TITLE
Add role levels so that super-admin can easily be filtered

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -33,6 +33,7 @@ class Role < ApplicationRecord
   belongs_to :business, required: false
 
   scope :for_business, ->(business) { where(business_id: [nil, business.id]) }
+  scope :settable_for_user, ->(user) { for_business(user.business).where(level: 0..user.role.level) }
   validates :name, presence: true, uniqueness: { scope: :business }
   validates :business, absence: true, if: ->(r) { r.name == SUPER_ADMIN }
 

--- a/app/views/configs/_user.html.slim
+++ b/app/views/configs/_user.html.slim
@@ -20,7 +20,7 @@
       .row
         .form_group.col-md-6
           = label_tag :role_id, 'Role'
-          = select_tag :role_id, options_from_collection_for_select(Role.for_business(current_user.business), :id, :pretty_name, (@user || current_user).role_id), class: 'form-control input-normal'
+          = select_tag :role_id, options_from_collection_for_select(Role.settable_for_user(current_user), :id, :pretty_name, (@user || current_user).role_id), class: 'form-control input-normal'
 
       .row
         .form_group.col-md-12

--- a/db/migrate/20170212212640_add_role_level.rb
+++ b/db/migrate/20170212212640_add_role_level.rb
@@ -1,0 +1,17 @@
+class AddRoleLevel < ActiveRecord::Migration[5.0]
+  def change
+    add_column :roles, :level, :integer, default: 0
+
+    execute <<~SQL
+      UPDATE roles
+      SET level = 1
+      WHERE name = 'admin'
+    SQL
+
+    execute <<~SQL
+      UPDATE roles
+      SET level = 2
+      WHERE name = 'super_admin'
+    SQL
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170208232430) do
+ActiveRecord::Schema.define(version: 20170212212640) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -92,6 +92,7 @@ ActiveRecord::Schema.define(version: 20170208232430) do
     t.datetime "created_at",               null: false
     t.datetime "updated_at",               null: false
     t.jsonb    "permissions", default: {}
+    t.integer  "level",       default: 0
     t.index ["business_id"], name: "index_roles_on_business_id", using: :btree
   end
 


### PR DESCRIPTION
Levels:

2 - super admin
1 - admin
0 - everyone else

You can only edit/set a role that is on a level
lower than yours.